### PR TITLE
Remove currentowner field from asobpsreport.yml

### DIFF
--- a/configs/reports/config/asobpsreport.yml
+++ b/configs/reports/config/asobpsreport.yml
@@ -64,12 +64,6 @@ ReportDefinitions:
         showColumn: true
         isLocalisationRequired: true
 
-      - name: currentowner
-        label: reports.obps.currentowner
-        type: string
-        source: obps
-        showColumn: false
-
       - name: planning_permit_no
         label: reports.obps.planningpermitno
         type: string
@@ -96,7 +90,6 @@ ReportDefinitions:
       bp.application_type as applicationtype, 
       land.occupancy_type,
       bp.status, 
-      case when st.isterminatestate=true then null else userassignee.name end as currentowner, 
       bp.planning_permit_no 
       FROM ug_bpa_buildingplans bp 
       INNER JOIN (


### PR DESCRIPTION
Removed 'currentowner' field from report configuration and SQL query.